### PR TITLE
Fix local paths in examples and add error reporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@ jspm-test.html
   &lt;script src="https://jspm.io/system@0.9.js">&lt;/script>
   &lt;script>
     // import 'app.js' from the current URL
-    System.import('~/app');
+    System.import('~/app').catch(console.error.bind(console));
   &lt;/script>
 ```
 
@@ -330,7 +330,7 @@ jspm-test.html
   &lt;script src="jspm_packages/system.js">&lt;/script>
   &lt;script src="config.js">&lt;/script>
   &lt;script>
-    System.import('~/app');
+    System.import('~/app').catch(console.error.bind(console));
   &lt;/script>
 ```
 
@@ -350,7 +350,7 @@ jspm-test.html
   &lt;script src="config.js">&lt;/script>
   &lt;script src="build.js">&lt;/script>
   &lt;script>
-    System.import('~/app');
+    System.import('~/app').catch(console.error.bind(console));
   &lt;/script>
 ```
 


### PR DESCRIPTION
At least in Firefox 33, `system@0.9.js` isn't a valid local path.

Also, without a `.catch()` statement, the module loader simply eats all the errors, which makes for a very frustrating initial experience.
