### PR TITLE
don't add target="_blank"

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,7 +484,6 @@ The CDN can also be tested from this page - try opening up the browser console a
       System['import']('showdown').then(function(showdown) {
         var converter = new showdown.Converter();
         document.querySelector('.content').innerHTML = converter.makeHtml(document.querySelector('markdown').textContent);
-        Array.prototype.forEach.call(document.querySelectorAll('a'), function(a) { if ((a.getAttribute('href') || '#').substr(0, 1) != '#') a.setAttribute('target', '_blank'); });
         Array.prototype.forEach.call(document.querySelectorAll('code.javascript'), function(code) {
           code.innerHTML = code.innerHTML
             .replace(/\/\/(.*)/gm, '<span class="comment">//$1</span>')


### PR DESCRIPTION
because it's rude to users - if they want to open their links in a new tab, then they will do so without it being forced on them