### PR TITLE
Point to where the source is

### DIFF
--- a/0.17-beta-guide/README.md
+++ b/0.17-beta-guide/README.md
@@ -1,0 +1,1 @@
+The source of the guide is at https://github.com/guybedford/jspm-beta-guide


### PR DESCRIPTION
Wanted to fix an issue I spotted at http://jspm.io/0.17-beta-guide/creating-a-project.html, and this shouldn't be more trouble than necessary.

Ideally, an edit link in each page would point directly to GitHub's UI for editing that file. This works great for the [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/) and [InfluxDB docs](https://docs.influxdata.com/influxdb/v1.0/query_language/spec/), for example.